### PR TITLE
Added support to send extra submission arguments

### DIFF
--- a/judge0api/submission.py
+++ b/judge0api/submission.py
@@ -143,7 +143,9 @@ class Submission:
         }
         r = client.session.get(f"{client.endpoint}/submissions/{self.token}/", headers=headers, params=params)
         r.raise_for_status()
-        self.set_properties(r)
+
+        json = r.json()
+        self.set_properties(dict(json))
 
     def submit(self, client):
         """

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -18,7 +18,7 @@ def test_homepage_example():
         stdin=b'Judge0',
         expected_output=b"Hello Judge0"
     )
-    time.sleep(2)
+    time.sleep(3)
     submission.load(client)
 
     assert submission.status['id'] == api.Judge0Status.ACCEPTED.value


### PR DESCRIPTION
Issue: #4 

There were no supported arguments to send via submit() if we want to send any of the _extra_send_fields.
I added **kwargs in submit() function and modified the Submission.set_attributes() to make it suitable for all types of arguments.